### PR TITLE
Fix grok api key issue in route.ts

### DIFF
--- a/app/api/analyze-symptoms/route.ts
+++ b/app/api/analyze-symptoms/route.ts
@@ -58,7 +58,7 @@ export async function POST(request: NextRequest) {
 
     // Make request to Groq API
     const response = await client.chat.completions.create({
-      model: "llama3-8b-8192",
+      model: "llama-3.1-8b-instant",
       messages: [
         {
           role: 'system',


### PR DESCRIPTION
Update Groq model name to `llama-3.1-8b-instant` to use a free tier model.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a410d6b-305a-4931-9f5d-190c9ea0ffa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a410d6b-305a-4931-9f5d-190c9ea0ffa9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

